### PR TITLE
fix: pull 100 teams per page

### DIFF
--- a/src/octokit-queries.ts
+++ b/src/octokit-queries.ts
@@ -8,7 +8,8 @@ export const getTeamSlugsForAuthor = async (
   ignoreSlugs: string[] = [],
 ): Promise<string[]> => {
   const { data: allTeams } = await octokit.rest.teams.list({
-    org,
+    org: org,
+    per_page: 100
   });
 
   const authorsTeamSlugs: string[] = [];


### PR DESCRIPTION
GitHub defaults to 30 teams per page, and we have 31 teams so this was breaking randomly. Bumping to the max of 100, as if we ever end up over 100 teams we'll probably have some other kind of solution in place at that point.